### PR TITLE
Adds a link to my 2011 Sunlight recap

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
         </div>
         <p style="text-align: right"><small>Attendees self-report in multiple categories.</small></p>
       </div>
-    </div>      
+    </div>
 
 	<img src="photos/2015/workshops.jpeg" title="Workshops at Open Data Day DC 2015" class="wide-image">
 
@@ -366,6 +366,7 @@
           <h3>2011</h3>
           <p>The first Open Data Day hackathon in DC was on Dec. 3, 2011 at the Martin Luther King Public Library with 45 participants. It was organized by Josh Tauberer (POPVOX) and Katie Filbert (Wikimedia DC).</p>
           <p>The theme of our hackathon was open government data, and participants worked on improving access to U.S. law, scanning federal spending for anomalies following Benford’s Law, understanding farm subsidy grants, building local transit apps, and keeping Congress accountable. Only about half of the participants were programmers, but everyone found a way to be involved.</p>
+          <p><a href="https://sunlightfoundation.com/blog/2011/12/08/sunlight-at-international-open-data-hackathon/">Eric's Recap</a></p>
           <p>See <a href="/static/img/origin-of-odddc.png">how it got started</a>.</p>
         </div>
         <div class="col-md-8 col-lg-6" style="padding-top: 60px">


### PR DESCRIPTION
Adds a link to the 2011 section, using the same markup and style as in previous years' sections:

![image](https://cloud.githubusercontent.com/assets/4592/13274319/526bfbb6-da78-11e5-905b-73694e507b7f.png)
